### PR TITLE
Add AI-driven maintenance prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+dashboard/node_modules/
+data/*.csv
+models/*.joblib
+schedules/*.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# PROJECT
+# AI-Driven Predictive Maintenance & Adaptive Production Scheduler
+
+This prototype demonstrates a pipeline for generating synthetic sensor data, training a failure prediction model, scheduling maintenance/production with Gurobi, simulating execution with SimPy, and visualising results via a Flask API and a React dashboard.
+
+## Setup
+
+### Python
+1. Create a virtual environment (optional).
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+### Front End
+```
+cd dashboard
+npm install
+```
+
+## Running the Pipeline
+
+1. **Generate data**
+   ```bash
+   python data_generator.py
+   ```
+2. **Train predictive model**
+   ```bash
+   python predictive_model.py
+   ```
+3. **Run scheduler**
+   ```bash
+   python scheduler.py
+   ```
+4. **Run simulation**
+   ```bash
+   python simulation.py
+   ```
+5. **Start API**
+   ```bash
+   python app.py
+   ```
+6. **Start React dashboard**
+   ```bash
+   cd dashboard && npm start
+   ```
+
+The dashboard provides buttons to trigger the API endpoints and displays the risk heatmap, schedule Gantt chart, and simulation report.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,86 @@
+from flask import Flask, request, jsonify
+from flasgger import Swagger
+
+import data_generator
+import predictive_model
+import scheduler
+import simulation
+
+app = Flask(__name__)
+swagger = Swagger(app)
+
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    """Generate synthetic sensor data
+    ---
+    post:
+      description: Generate new sensor data
+      responses:
+        200:
+          description: path to csv
+    """
+    path = data_generator.generate_sensor_data()
+    return jsonify({'csv_path': path})
+
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    """Predict failure risks for posted data
+    ---
+    post:
+      parameters:
+        - in: body
+          name: payload
+          schema:
+            type: array
+            items:
+              type: object
+              properties:
+                temperature:
+                  type: number
+                vibration:
+                  type: number
+                machine_id:
+                  type: integer
+      responses:
+        200:
+          description: predictions
+    """
+    payload = request.get_json()
+    model = predictive_model.joblib.load('models/predictive_model.joblib')
+    X = [[p['temperature'], p['vibration'], p['machine_id']] for p in payload]
+    probs = model.predict_proba(X)[:, 1].tolist()
+    return jsonify({'predictions': probs})
+
+
+@app.route('/schedule', methods=['POST'])
+def schedule_route():
+    """Run the scheduler and return JSON schedule
+    ---
+    post:
+      responses:
+        200:
+          description: schedule
+    """
+    path = scheduler.demo_schedule()
+    with open(path) as f:
+        data = f.read()
+    return jsonify({'schedule': data})
+
+
+@app.route('/simulate', methods=['POST'])
+def simulate_route():
+    """Run simulation based on schedule and predictive model
+    ---
+    post:
+      responses:
+        200:
+          description: simulation results
+    """
+    result = simulation.simulate()
+    return jsonify(result)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "react-plotly.js": "^2.5.1",
+    "plotly.js": "^2.24.1"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/dashboard/src/App.js
+++ b/dashboard/src/App.js
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import Plot from 'react-plotly.js';
+
+function App() {
+  const [heatData, setHeatData] = useState([]);
+  const [schedule, setSchedule] = useState([]);
+  const [report, setReport] = useState(null);
+
+  const api = async (endpoint, payload) => {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload ? JSON.stringify(payload) : null,
+    });
+    return res.json();
+  };
+
+  const generate = async () => {
+    await api('/generate');
+  };
+
+  const predict = async () => {
+    const samples = Array.from({ length: 10 }).map((_, i) => ({
+      temperature: 70 + Math.random() * 10,
+      vibration: 0.5 + Math.random() * 0.2,
+      machine_id: (i % 3) + 1,
+    }));
+    const res = await api('/predict', samples);
+    setHeatData(res.predictions);
+  };
+
+  const scheduleFn = async () => {
+    const res = await api('/schedule');
+    setSchedule(JSON.parse(res.schedule));
+  };
+
+  const simulate = async () => {
+    const res = await api('/simulate');
+    setReport(res);
+  };
+
+  const heatmap = (
+    <Plot
+      data={[{
+        z: [heatData],
+        type: 'heatmap',
+      }]}
+      layout={{ title: 'Failure Risk Heatmap' }}
+    />
+  );
+
+  const gantt = (
+    <Plot
+      data={schedule.map(item => ({
+        x: [item.start, item.end],
+        y: [item.machine, item.machine],
+        mode: 'lines',
+        line: { width: 20 },
+        name: item.id,
+      }))}
+      layout={{ title: 'Schedule', yaxis: { autorange: 'reversed' } }}
+    />
+  );
+
+  return (
+    <div>
+      <h1>AI-Driven Predictive Maintenance</h1>
+      <button onClick={generate}>Generate Data</button>
+      <button onClick={predict}>Predict</button>
+      <button onClick={scheduleFn}>Schedule</button>
+      <button onClick={simulate}>Simulate</button>
+      {heatData.length > 0 && heatmap}
+      {schedule.length > 0 && gantt}
+      {report && <pre>{JSON.stringify(report, null, 2)}</pre>}
+    </div>
+  );
+}
+
+export default App;

--- a/dashboard/src/index.js
+++ b/dashboard/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/data_generator.py
+++ b/data_generator.py
@@ -1,0 +1,36 @@
+import os
+import numpy as np
+import pandas as pd
+
+
+def generate_sensor_data(output_path: str = "data/synthetic_data.csv", seed: int = 42) -> str:
+    """Generate synthetic sensor data for 3 machines at 6 hour intervals."""
+    np.random.seed(seed)
+    start = pd.Timestamp("2023-01-01")
+    periods = 120  # 30 days of data in 6 hour intervals
+    freq = "6H"
+    records = []
+    for machine in range(1, 4):
+        for i in range(periods):
+            ts = start + pd.Timedelta(hours=6 * i)
+            temperature = np.random.normal(loc=70, scale=5)
+            vibration = np.random.normal(loc=0.5, scale=0.1)
+            # Failure probability increases with high temp and vibration
+            prob = 1 / (1 + np.exp(-(temperature - 75) * 0.2 - (vibration - 0.5) * 5))
+            failure = np.random.binomial(1, prob * 0.1)  # keep failures relatively rare
+            records.append([
+                ts,
+                machine,
+                round(temperature, 2),
+                round(vibration, 3),
+                failure,
+            ])
+    df = pd.DataFrame(records, columns=["timestamp", "machine_id", "temperature", "vibration", "failure"])
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    df.to_csv(output_path, index=False)
+    print(f"Synthetic data saved to {output_path}")
+    return output_path
+
+
+if __name__ == "__main__":
+    generate_sensor_data()

--- a/predictive_model.py
+++ b/predictive_model.py
@@ -1,0 +1,37 @@
+import os
+import joblib
+import pandas as pd
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import accuracy_score, roc_auc_score
+
+
+def train_model(csv_path: str = "data/synthetic_data.csv", model_path: str = "models/predictive_model.joblib") -> str:
+    """Train a failure prediction model from the synthetic data."""
+    df = pd.read_csv(csv_path)
+    X = df[["temperature", "vibration", "machine_id"]]
+    y = df["failure"]
+
+    X_train, X_val, y_train, y_val = train_test_split(
+        X, y, test_size=0.2, random_state=42, stratify=y
+    )
+
+    clf = RandomForestClassifier(n_estimators=100, random_state=42)
+    clf.fit(X_train, y_train)
+
+    y_pred = clf.predict(X_val)
+    y_prob = clf.predict_proba(X_val)[:, 1]
+    acc = accuracy_score(y_val, y_pred)
+    auc = roc_auc_score(y_val, y_prob)
+
+    print(f"Validation Accuracy: {acc:.3f}")
+    print(f"Validation ROC-AUC: {auc:.3f}")
+
+    os.makedirs(os.path.dirname(model_path), exist_ok=True)
+    joblib.dump(clf, model_path)
+    print(f"Model saved to {model_path}")
+    return model_path
+
+
+if __name__ == "__main__":
+    train_model()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+pandas
+numpy
+scikit-learn
+joblib
+gurobipy
+simpy
+Flask
+flasgger
+plotly

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,117 @@
+import json
+import os
+from typing import List, Dict
+
+from gurobipy import Model, GRB
+
+
+class Job:
+    def __init__(self, jid: int, machine: int, duration: int, due: int):
+        self.jid = jid
+        self.machine = machine
+        self.duration = duration
+        self.due = due
+
+
+class Maintenance:
+    def __init__(self, machine: int, duration: int):
+        self.machine = machine
+        self.duration = duration
+
+
+def build_schedule(jobs: List[Job], maints: List[Maintenance], output_path: str = "schedules/schedule.json") -> str:
+    m = Model("scheduler")
+    m.setParam("OutputFlag", 0)
+
+    big_m = 1000
+
+    # Variables for job start times and tardiness
+    start = {j.jid: m.addVar(lb=0, name=f"start_j{j.jid}") for j in jobs}
+    tardiness = {
+        j.jid: m.addVar(lb=0, name=f"late_j{j.jid}") for j in jobs
+    }
+
+    # Maintenance start times
+    mstart = {
+        (mt.machine): m.addVar(lb=0, name=f"start_m{mt.machine}") for mt in maints
+    }
+
+    m.update()
+
+    # Completion times
+    completion = {j.jid: start[j.jid] + j.duration for j in jobs}
+    mcompletion = {mt.machine: mstart[mt.machine] + mt.duration for mt in maints}
+
+    # Tardiness constraints
+    for j in jobs:
+        m.addConstr(tardiness[j.jid] >= completion[j.jid] - j.due)
+        m.addConstr(tardiness[j.jid] >= 0)
+
+    # Non-overlap constraints per machine
+    for mach in {j.machine for j in jobs}:
+        machine_jobs = [j for j in jobs if j.machine == mach]
+        maint = [mt for mt in maints if mt.machine == mach][0]
+        tasks = machine_jobs + [maint]
+        for i in range(len(tasks)):
+            for k in range(i + 1, len(tasks)):
+                ti = tasks[i]
+                tk = tasks[k]
+                y = m.addVar(vtype=GRB.BINARY, name=f"y_{ti}_{tk}")
+                si = start[ti.jid] if isinstance(ti, Job) else mstart[ti.machine]
+                di = ti.duration
+                sk = start[tk.jid] if isinstance(tk, Job) else mstart[tk.machine]
+                dk = tk.duration
+                m.addConstr(si + di <= sk + big_m * (1 - y))
+                m.addConstr(sk + dk <= si + big_m * y)
+
+    # Objective: minimize downtime (maintenance durations) + late penalties
+    downtime = sum(mt.duration for mt in maints)
+    penalty = sum(tardiness[j.jid] for j in jobs)
+    m.setObjective(downtime + 10 * penalty, GRB.MINIMIZE)
+
+    m.optimize()
+
+    schedule: List[Dict] = []
+    for j in jobs:
+        schedule.append(
+            {
+                "id": f"job{j.jid}",
+                "machine": j.machine,
+                "type": "job",
+                "start": start[j.jid].X,
+                "end": completion[j.jid].getValue(),
+            }
+        )
+    for mt in maints:
+        schedule.append(
+            {
+                "id": f"maint{mt.machine}",
+                "machine": mt.machine,
+                "type": "maintenance",
+                "start": mstart[mt.machine].X,
+                "end": mcompletion[mt.machine].getValue(),
+            }
+        )
+
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(schedule, f, indent=2)
+    print(f"Schedule saved to {output_path}")
+    return output_path
+
+
+def demo_schedule() -> str:
+    jobs = [
+        Job(1, 1, 4, 20),
+        Job(2, 2, 6, 30),
+        Job(3, 3, 3, 25),
+        Job(4, 1, 5, 40),
+        Job(5, 2, 2, 12),
+        Job(6, 3, 7, 35),
+    ]
+    maints = [Maintenance(1, 3), Maintenance(2, 4), Maintenance(3, 5)]
+    return build_schedule(jobs, maints)
+
+
+if __name__ == "__main__":
+    demo_schedule()

--- a/simulation.py
+++ b/simulation.py
@@ -1,0 +1,75 @@
+import json
+import os
+from typing import Dict, List
+
+import joblib
+import numpy as np
+import simpy
+
+
+class Machine:
+    def __init__(self, env: simpy.Environment, machine_id: int):
+        self.env = env
+        self.id = machine_id
+        self.resource = simpy.Resource(env, capacity=1)
+        self.prod_time = 0.0
+        self.down_time = 0.0
+
+
+class Simulator:
+    def __init__(self, schedule_path: str, model_path: str):
+        with open(schedule_path) as f:
+            self.schedule = sorted(json.load(f), key=lambda x: x["start"])
+        self.model = joblib.load(model_path)
+        self.env = simpy.Environment()
+        self.machines = {i: Machine(self.env, i) for i in {t["machine"] for t in self.schedule}}
+
+    def run(self):
+        for task in self.schedule:
+            self.env.process(self.handle_task(task))
+        self.env.run()
+        cycle_time = self.env.now
+        util = {
+            m_id: mach.prod_time / cycle_time for m_id, mach in self.machines.items()
+        }
+        return {
+            "cycle_time": cycle_time,
+            "utilization": util,
+            "unscheduled_downtime": {
+                m_id: mach.down_time for m_id, mach in self.machines.items()
+            },
+        }
+
+    def handle_task(self, task: Dict):
+        machine = self.machines[task["machine"]]
+        with machine.resource.request() as req:
+            yield req
+            # wait until scheduled start
+            if self.env.now < task["start"]:
+                yield self.env.timeout(task["start"] - self.env.now)
+            duration = task["end"] - task["start"]
+            if task["type"] == "job":
+                # generate random features for this job
+                temp = np.random.normal(70, 5)
+                vib = np.random.normal(0.5, 0.1)
+                prob = self.model.predict_proba([[temp, vib, task["machine"]]])[0, 1]
+                if np.random.rand() < prob:
+                    repair = 2.0
+                    machine.down_time += repair
+                    yield self.env.timeout(repair)
+            machine.prod_time += duration
+            yield self.env.timeout(duration)
+
+
+def simulate(schedule_path: str = "schedules/schedule.json", model_path: str = "models/predictive_model.joblib") -> Dict:
+    sim = Simulator(schedule_path, model_path)
+    result = sim.run()
+    report_path = os.path.join("schedules", "simulation_report.json")
+    with open(report_path, "w") as f:
+        json.dump(result, f, indent=2)
+    print(f"Simulation report saved to {report_path}")
+    return result
+
+
+if __name__ == "__main__":
+    simulate()


### PR DESCRIPTION
## Summary
- generate synthetic sensor data for 3 machines
- train a RandomForest model to predict failures
- schedule maintenance jobs via Gurobi
- simulate production and downtime with SimPy
- expose a Flask API with Swagger docs
- create a React dashboard to visualize risks and schedule
- add setup instructions

## Testing
- `python -m py_compile data_generator.py predictive_model.py scheduler.py simulation.py app.py`
- `python data_generator.py`
- `python predictive_model.py`
- `python scheduler.py`
- `python simulation.py`


------
https://chatgpt.com/codex/tasks/task_e_68530c91480083339b359f3ba5f5f680