### PR TITLE
Add predictive maintenance prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+node_modules/
+dashboard/node_modules/
+synthetic_data.csv
+models/
+schedule.json

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# PROJECT
+# AI-Driven Predictive Maintenance & Adaptive Production Scheduler
+
+Prototype project demonstrating data generation, predictive maintenance using ML, production scheduling with MIP, simulation and a simple dashboard.
+
+## Setup
+
+### Python
+1. Create virtual environment and install requirements.
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+2. Generate data
+```bash
+python data_generator.py
+```
+
+3. Train predictive model
+```bash
+python predictive_model.py
+```
+
+4. Run scheduler (requires Gurobi installed/licensed)
+```bash
+python scheduler.py
+```
+
+5. Run simulation
+```bash
+python simulation.py
+```
+
+6. Start API
+```bash
+python app.py
+```
+
+### Frontend
+Use Node.js to install dependencies and run the dashboard.
+```bash
+cd dashboard
+npm install
+npm start
+```
+
+The React app expects the Flask backend on `http://localhost:5000`.
+
+## Files
+- `data_generator.py` – create synthetic machine data.
+- `predictive_model.py` – train RandomForest model to predict failures.
+- `scheduler.py` – build and solve maintenance/production schedule with Gurobi.
+- `simulation.py` – discrete event simulation via SimPy.
+- `app.py` – Flask API exposing pipeline endpoints.
+- `dashboard/` – React single-page application displaying heatmaps and schedule.
+
+## Requirements
+See `requirements.txt` and `dashboard/package.json` for Python and JavaScript dependencies.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,94 @@
+from flask import Flask, jsonify, request
+from flasgger import Swagger
+import json
+import pandas as pd
+
+import data_generator
+import predictive_model
+import scheduler
+import simulation
+
+app = Flask(__name__)
+swagger = Swagger(app)
+
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    """Generate synthetic data
+    ---
+    responses:
+      200:
+        description: CSV path
+    """
+    df = data_generator.generate_data()
+    csv_path = 'synthetic_data.csv'
+    df.to_csv(csv_path, index=False)
+    return jsonify({'csv': csv_path})
+
+
+@app.route('/predict', methods=['POST'])
+def predict():
+    """Train model and return failure probabilities for provided data
+    ---
+    consumes:
+      - application/json
+    parameters:
+      - in: body
+        name: data
+        schema:
+          type: array
+          items:
+            type: object
+    responses:
+      200:
+        description: Prediction results
+    """
+    data = request.get_json() or []
+    if not data:
+        df = pd.read_csv('synthetic_data.csv')
+        X = df[["machine", "temperature", "vibration"]]
+    else:
+        df = pd.DataFrame(data)
+        X = df[["machine", "temperature", "vibration"]]
+    model = predictive_model.train_model()
+    proba = model.predict_proba(X)[:, 1]
+    df['failure_risk'] = proba
+    return df.to_json(orient='records')
+
+
+@app.route('/schedule', methods=['POST'])
+def schedule_endpoint():
+    """Run scheduler
+    ---
+    responses:
+      200:
+        description: schedule JSON
+    """
+    jobs = scheduler.build_jobs()
+    try:
+        sched = scheduler.schedule(jobs)
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+    path = 'schedule.json'
+    with open(path, 'w') as f:
+        json.dump(sched, f)
+    return jsonify(sched)
+
+
+@app.route('/simulate', methods=['POST'])
+def simulate_endpoint():
+    """Run simulation
+    ---
+    responses:
+      200:
+        description: Simulation results
+    """
+    try:
+        res = simulation.simulate('schedule.json')
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+    return jsonify(res)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "plotly.js": "^2.24.1",
+    "react-plotly.js": "^2.5.1",
+    "axios": "^1.4.0"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build"
+  }
+}

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>AI Maintenance Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/dashboard/src/App.js
+++ b/dashboard/src/App.js
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import Plot from 'react-plotly.js';
+import axios from 'axios';
+
+function App() {
+  const [riskData, setRiskData] = useState([]);
+  const [schedule, setSchedule] = useState(null);
+  const [simReport, setSimReport] = useState(null);
+
+  const callEndpoint = async (path) => {
+    const res = await axios.post(`http://localhost:5000${path}`);
+    return res.data;
+  };
+
+  const generate = async () => {
+    await callEndpoint('/generate');
+  };
+  const predict = async () => {
+    const data = await callEndpoint('/predict');
+    setRiskData(JSON.parse(data));
+  };
+  const scheduleRun = async () => {
+    const data = await callEndpoint('/schedule');
+    setSchedule(data);
+  };
+  const simulate = async () => {
+    const data = await callEndpoint('/simulate');
+    setSimReport(data);
+  };
+
+  const heatmap = riskData.length > 0 && (
+    <Plot
+      data={[{
+        x: riskData.map(d => d.timestamp),
+        y: riskData.map(d => `Machine ${d.machine}`),
+        z: riskData.map(d => d.failure_risk),
+        type: 'heatmap',
+        colorscale: 'Reds'
+      }]}
+      layout={{ title: 'Failure Risk Heatmap' }}
+    />
+  );
+
+  const gantt = schedule && (
+    <Plot
+      data={schedule.jobs.map(j => ({
+        x: [j.start, j.finish],
+        y: [`Machine ${j.machine}`],
+        type: 'bar',
+        orientation: 'h',
+        name: j.id
+      }))}
+      layout={{ barmode: 'stack', title: 'Schedule' }}
+    />
+  );
+
+  return (
+    <div className="App">
+      <h1>AI-Driven Predictive Maintenance</h1>
+      <button onClick={generate}>Generate Data</button>
+      <button onClick={predict}>Predict Failure</button>
+      <button onClick={scheduleRun}>Schedule</button>
+      <button onClick={simulate}>Simulate</button>
+      {heatmap}
+      {gantt}
+      {simReport && <pre>{JSON.stringify(simReport, null, 2)}</pre>}
+    </div>
+  );
+}
+
+export default App;

--- a/dashboard/src/index.js
+++ b/dashboard/src/index.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/data_generator.py
+++ b/data_generator.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas as pd
+from datetime import datetime, timedelta
+
+
+def generate_data(days: int = 30, freq_hours: int = 6, machines: int = 3) -> pd.DataFrame:
+    """Generate synthetic sensor data and failure labels."""
+    records = []
+    start = datetime.now().replace(minute=0, second=0, microsecond=0) - timedelta(days=days)
+    timestamps = [start + timedelta(hours=i * freq_hours) for i in range(int(days * 24 / freq_hours))]
+    for m in range(1, machines + 1):
+        temp_base = 70 + 5 * np.random.randn()
+        vib_base = 0.5 + 0.1 * np.random.randn()
+        for ts in timestamps:
+            temp = temp_base + np.random.randn() * 5
+            vib = vib_base + np.random.randn() * 0.05
+            # failure probability increases with high temperature and vibration
+            prob_fail = max(0, min(1, 0.01 * (temp - 65) + 0.5 * (vib - 0.5)))
+            failure = np.random.rand() < prob_fail
+            records.append({
+                "timestamp": ts,
+                "machine": m,
+                "temperature": round(temp, 2),
+                "vibration": round(vib, 3),
+                "failure": int(failure)
+            })
+    df = pd.DataFrame(records)
+    return df
+
+
+def main():
+    df = generate_data()
+    csv_path = "synthetic_data.csv"
+    df.to_csv(csv_path, index=False)
+    print(f"Generated data saved to {csv_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/predictive_model.py
+++ b/predictive_model.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score, roc_auc_score
+import joblib
+
+
+def train_model(csv_path: str = "synthetic_data.csv", model_path: str = "models/predictive_model.pkl"):
+    df = pd.read_csv(csv_path)
+    X = df[["machine", "temperature", "vibration"]]
+    y = df["failure"]
+    X_train, X_val, y_train, y_val = train_test_split(X, y, test_size=0.2, random_state=42)
+
+    clf = RandomForestClassifier(n_estimators=100, random_state=42)
+    clf.fit(X_train, y_train)
+
+    y_pred = clf.predict(X_val)
+    y_proba = clf.predict_proba(X_val)[:, 1]
+    acc = accuracy_score(y_val, y_pred)
+    auc = roc_auc_score(y_val, y_proba)
+    print(f"Validation Accuracy: {acc:.4f}")
+    print(f"Validation ROC-AUC: {auc:.4f}")
+
+    joblib.dump(clf, model_path)
+    print(f"Model saved to {model_path}")
+
+    return clf
+
+
+def main():
+    train_model()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+flask
+flasgger
+pandas
+numpy
+scikit-learn
+joblib
+gurobipy
+simpy
+plotly

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,98 @@
+import json
+from typing import List, Dict
+
+try:
+    import gurobipy as gp
+    from gurobipy import GRB
+except Exception as e:  # if gurobipy not installed
+    gp = None
+    GRB = None
+
+
+Job = Dict[str, any]
+
+
+def build_jobs() -> List[Job]:
+    """Return a list of jobs with durations and deadlines assigned to machines."""
+    jobs = [
+        {"id": "J1", "machine": 1, "duration": 3, "deadline": 10},
+        {"id": "J2", "machine": 2, "duration": 4, "deadline": 12},
+        {"id": "J3", "machine": 3, "duration": 2, "deadline": 8},
+        {"id": "J4", "machine": 1, "duration": 5, "deadline": 15},
+        {"id": "J5", "machine": 2, "duration": 3, "deadline": 9},
+    ]
+    return jobs
+
+
+def schedule(jobs: List[Job], maint_duration: int = 2) -> Dict:
+    if gp is None:
+        raise ImportError("gurobipy is required to run the scheduler")
+
+    machines = sorted(set(job["machine"] for job in jobs))
+    model = gp.Model("scheduler")
+
+    # variables
+    start = {j["id"]: model.addVar(lb=0, name=f"start_{j['id']}") for j in jobs}
+    maintenance = {m: model.addVar(lb=0, name=f"maint_{m}") for m in machines}
+
+    # completion times
+    completion = {j["id"]: start[j["id"]] + j["duration"] for j in jobs}
+    maint_comp = {m: maintenance[m] + maint_duration for m in machines}
+
+    bigM = 1000
+    # ordering constraints for jobs on same machine
+    for j1 in jobs:
+        for j2 in jobs:
+            if j1 == j2:
+                continue
+            if j1["machine"] == j2["machine"]:
+                y = model.addVar(vtype=GRB.BINARY, name=f"y_{j1['id']}_{j2['id']}")
+                model.addConstr(start[j2["id"]] >= completion[j1["id"]] - bigM * (1 - y))
+                model.addConstr(start[j1["id"]] >= completion[j2["id"]] - bigM * y)
+
+    # maintenance must happen before or after jobs on same machine
+    for j in jobs:
+        m = j["machine"]
+        z = model.addVar(vtype=GRB.BINARY, name=f"z_{j['id']}")
+        model.addConstr(start[j["id"]] >= maint_comp[m] - bigM * (1 - z))
+        model.addConstr(maintenance[m] >= completion[j["id"]] - bigM * z)
+
+    # objective: minimize late penalties and downtime (maintenance duration)
+    late = {j["id"]: model.addVar(lb=0, name=f"late_{j['id']}") for j in jobs}
+    for j in jobs:
+        model.addConstr(late[j["id"]] >= completion[j["id"]] - j["deadline"])
+
+    downtime = sum(maint_duration for _ in machines)
+    model.setObjective(gp.quicksum(late.values()) + downtime, GRB.MINIMIZE)
+
+    model.optimize()
+
+    schedule = {
+        "jobs": [
+            {
+                "id": j["id"],
+                "machine": j["machine"],
+                "start": start[j["id"]].X,
+                "finish": completion[j["id"]].X,
+            }
+            for j in jobs
+        ],
+        "maintenance": [
+            {"machine": m, "start": maintenance[m].X, "finish": maint_comp[m].X}
+            for m in machines
+        ],
+    }
+    return schedule
+
+
+def main():
+    jobs = build_jobs()
+    sched = schedule(jobs)
+    path = "schedule.json"
+    with open(path, "w") as f:
+        json.dump(sched, f, indent=2)
+    print(f"Schedule saved to {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/simulation.py
+++ b/simulation.py
@@ -1,0 +1,61 @@
+import json
+import random
+import simpy
+import joblib
+import pandas as pd
+from predictive_model import train_model
+
+
+def load_failure_model(model_path="models/predictive_model.pkl"):
+    return joblib.load(model_path)
+
+
+def simulate(schedule_json: str, model_path: str = "models/predictive_model.pkl"):
+    with open(schedule_json) as f:
+        sched = json.load(f)
+
+    model = load_failure_model(model_path)
+
+    env = simpy.Environment()
+    results = {"utilization": {}, "unscheduled_downtime": {}, "cycle_time": 0}
+
+    machines = {m: simpy.Resource(env, capacity=1) for m in range(1, 4)}
+    downtime = {m: 0 for m in range(1, 4)}
+    busy_time = {m: 0 for m in range(1, 4)}
+
+    def run_task(machine_id, start, duration, task_id):
+        yield env.timeout(max(0, start - env.now))
+        with machines[machine_id].request() as req:
+            yield req
+            start_time = env.now
+            for t in range(int(duration)):
+                # evaluate failure probability using model
+                data = pd.DataFrame([[machine_id, random.uniform(60, 80), random.uniform(0.45, 0.55)]],
+                                    columns=["machine", "temperature", "vibration"])
+                prob = model.predict_proba(data)[:, 1][0]
+                if random.random() < prob * 0.1:  # scaled
+                    downtime[machine_id] += 1
+                    yield env.timeout(1)
+                yield env.timeout(1)
+            busy_time[machine_id] += env.now - start_time
+
+    for j in sched["jobs"]:
+        env.process(run_task(j["machine"], j["start"], j["finish"] - j["start"], j["id"]))
+    for m in sched["maintenance"]:
+        env.process(run_task(m["machine"], m["start"], m["finish"] - m["start"], f"M{m['machine']}"))
+
+    env.run()
+    results["cycle_time"] = env.now
+    for m in machines:
+        results["utilization"][m] = busy_time[m] / env.now if env.now else 0
+        results["unscheduled_downtime"][m] = downtime[m]
+    return results
+
+
+def main():
+    res = simulate("schedule.json")
+    print(json.dumps(res, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate synthetic machine data
- train RandomForest classifier for failures
- schedule jobs & maintenance via MIP with Gurobi
- simulate operations with SimPy
- expose Flask API with Swagger docs
- create React dashboard for visualization
- document setup in README

## Testing
- `python -m py_compile data_generator.py predictive_model.py scheduler.py simulation.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68530c91480083339b359f3ba5f5f680